### PR TITLE
Moved addition installation steps under "Installation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,73 @@ npm install vue-bootstrap-datetimepicker --save
 yarn add vue-bootstrap-datetimepicker
 ```
 
+### Install in non-module environments (without webpack)
+* Acquire required files
+```html
+<!-- Date-picker dependency-->
+<script src="https://unpkg.com/jquery@3.2.1/dist/jquery.min.js"></script>
+<script src="https://unpkg.com/moment@2.18.1/min/moment.min.js"></script>
+<link href="https://unpkg.com/bootstrap@3.3.7/dist/css/bootstrap.min.css" rel="stylesheet">
+
+<!-- Date-picker itself -->
+<script src="https://unpkg.com/eonasdan-bootstrap-datetimepicker@4.17.47/build/js/bootstrap-datetimepicker.min.js"></script>
+<link href="https://unpkg.com/eonasdan-bootstrap-datetimepicker@4.17.47/build/css/bootstrap-datetimepicker.min.css" rel="stylesheet">
+
+<!-- Vue js -->
+<script src="https://unpkg.com/vue@2.5/dist/vue.min.js"></script>
+<!-- Lastly add this package -->
+<script src="https://unpkg.com/vue-bootstrap-datetimepicker"></script>
+```
+* Use the component anywhere in your app like this
+```html
+<!-- index.html -->
+<div id="app" class="container">
+  <div class="row">
+    <div class="col-md-12">
+      <date-picker v-model="date" name="date-of-birth"></date-picker>
+    </div>
+  </div>
+</div>
+<script>
+  // Initialize as global component
+  Vue.component('date-picker', VueBootstrapDatetimePicker.default);
+  
+  new Vue({
+    el: '#app',
+    data: {
+      date: null
+    },    
+  });
+</script>
+```
+
+#### Using Webpack? 
+* Webpack users need to configure [ProvidePlugin](https://webpack.js.org/plugins/provide-plugin/)
+```js
+// webpack.config.js
+plugins: [
+    new webpack.ProvidePlugin({
+      Vue: ['vue/dist/vue.esm.js', 'default'],
+      jQuery: 'jquery',
+      'window.jQuery': 'jquery',
+      $: 'jquery',
+      moment: 'moment',
+    }),
+  ]  
+```
+
+#### Using Laravel Mix ?
+* Update your `webpack.mix.js` file, [ref](https://github.com/JeffreyWay/laravel-mix/blob/master/docs/autoloading.md)
+```js
+// webpack.mix.js
+mix.autoload({
+    'jquery': ['$', 'window.jQuery', 'jQuery'],
+    'vue': ['Vue','window.Vue'],   
+    'moment': ['moment','window.moment'],   
+  })
+```
+
+
 ## Requirements
 * Bootstrap ^3.3.7 (only css)
 * jQuery >=1.8.3 || ^3.2.1
@@ -102,71 +169,7 @@ The component accepts these props:
 | config          | Object             | `{}` | Datetime picker configuration [options](http://eonasdan.github.io/bootstrap-datetimepicker/Options/)|
 | wrap            | Boolean            | `false` | Set this to true when wrapped in 'input-group' |
 
-## Install in non-module environments (without webpack)
-* Acquire required files
-```html
-<!-- Date-picker dependency-->
-<script src="https://unpkg.com/jquery@3.2.1/dist/jquery.min.js"></script>
-<script src="https://unpkg.com/moment@2.18.1/min/moment.min.js"></script>
-<link href="https://unpkg.com/bootstrap@3.3.7/dist/css/bootstrap.min.css" rel="stylesheet">
 
-<!-- Date-picker itself -->
-<script src="https://unpkg.com/eonasdan-bootstrap-datetimepicker@4.17.47/build/js/bootstrap-datetimepicker.min.js"></script>
-<link href="https://unpkg.com/eonasdan-bootstrap-datetimepicker@4.17.47/build/css/bootstrap-datetimepicker.min.css" rel="stylesheet">
-
-<!-- Vue js -->
-<script src="https://unpkg.com/vue@2.5/dist/vue.min.js"></script>
-<!-- Lastly add this package -->
-<script src="https://unpkg.com/vue-bootstrap-datetimepicker"></script>
-```
-* Use the component anywhere in your app like this
-```html
-<!-- index.html -->
-<div id="app" class="container">
-  <div class="row">
-    <div class="col-md-12">
-      <date-picker v-model="date" name="date-of-birth"></date-picker>
-    </div>
-  </div>
-</div>
-<script>
-  // Initialize as global component
-  Vue.component('date-picker', VueBootstrapDatetimePicker.default);
-  
-  new Vue({
-    el: '#app',
-    data: {
-      date: null
-    },    
-  });
-</script>
-```
-
-### Using Webpack? 
-* Webpack users need to configure [ProvidePlugin](https://webpack.js.org/plugins/provide-plugin/)
-```js
-// webpack.config.js
-plugins: [
-    new webpack.ProvidePlugin({
-      Vue: ['vue/dist/vue.esm.js', 'default'],
-      jQuery: 'jquery',
-      'window.jQuery': 'jquery',
-      $: 'jquery',
-      moment: 'moment',
-    }),
-  ]  
-```
-
-### Using Laravel Mix ?
-* Update your `webpack.mix.js` file, [ref](https://github.com/JeffreyWay/laravel-mix/blob/master/docs/autoloading.md)
-```js
-// webpack.mix.js
-mix.autoload({
-    'jquery': ['$', 'window.jQuery', 'jQuery'],
-    'vue': ['Vue','window.Vue'],   
-    'moment': ['moment','window.moment'],   
-  })
-```
 
 ## Run examples on your localhost
 * Clone this repo

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ Vue.js v2.x component for [eonasdan-bootstrap-datetimepicker](http://eonasdan.gi
 * Emits all possible events      
 * Play nice with [vee-validate](https://github.com/logaretm/vee-validate) validation library
 
-
+## Requirements
+* Bootstrap ^3.3.7 (only css)
+* jQuery >=1.8.3 || ^3.2.1
+* [Moment.js](https://momentjs.com/) ^2.18
+ 
 ## Installation
 ```bash
 # npm
@@ -31,47 +35,7 @@ npm install vue-bootstrap-datetimepicker --save
 # Yarn
 yarn add vue-bootstrap-datetimepicker
 ```
-
-### Install in non-module environments (without webpack)
-* Acquire required files
-```html
-<!-- Date-picker dependency-->
-<script src="https://unpkg.com/jquery@3.2.1/dist/jquery.min.js"></script>
-<script src="https://unpkg.com/moment@2.18.1/min/moment.min.js"></script>
-<link href="https://unpkg.com/bootstrap@3.3.7/dist/css/bootstrap.min.css" rel="stylesheet">
-
-<!-- Date-picker itself -->
-<script src="https://unpkg.com/eonasdan-bootstrap-datetimepicker@4.17.47/build/js/bootstrap-datetimepicker.min.js"></script>
-<link href="https://unpkg.com/eonasdan-bootstrap-datetimepicker@4.17.47/build/css/bootstrap-datetimepicker.min.css" rel="stylesheet">
-
-<!-- Vue js -->
-<script src="https://unpkg.com/vue@2.5/dist/vue.min.js"></script>
-<!-- Lastly add this package -->
-<script src="https://unpkg.com/vue-bootstrap-datetimepicker"></script>
-```
-* Use the component anywhere in your app like this
-```html
-<!-- index.html -->
-<div id="app" class="container">
-  <div class="row">
-    <div class="col-md-12">
-      <date-picker v-model="date" name="date-of-birth"></date-picker>
-    </div>
-  </div>
-</div>
-<script>
-  // Initialize as global component
-  Vue.component('date-picker', VueBootstrapDatetimePicker.default);
   
-  new Vue({
-    el: '#app',
-    data: {
-      date: null
-    },    
-  });
-</script>
-```
-
 #### Using Webpack? 
 * Webpack users need to configure [ProvidePlugin](https://webpack.js.org/plugins/provide-plugin/)
 ```js
@@ -98,13 +62,7 @@ mix.autoload({
   })
 ```
 
-
-## Requirements
-* Bootstrap ^3.3.7 (only css)
-* jQuery >=1.8.3 || ^3.2.1
-* [Moment.js](https://momentjs.com/) ^2.18
-    
-## Usage
+## Usage Example
 ```html
 <template>
   <div class="container">
@@ -169,7 +127,26 @@ The component accepts these props:
 | config          | Object             | `{}` | Datetime picker configuration [options](http://eonasdan.github.io/bootstrap-datetimepicker/Options/)|
 | wrap            | Boolean            | `false` | Set this to true when wrapped in 'input-group' |
 
+### Install in non-module environments (without webpack)
+```html
+<!-- Date-picker dependencies -->
+<script src="https://unpkg.com/jquery@3.2.1/dist/jquery.min.js"></script>
+<script src="https://unpkg.com/moment@2.18.1/min/moment.min.js"></script>
+<link href="https://unpkg.com/bootstrap@3.3.7/dist/css/bootstrap.min.css" rel="stylesheet">
 
+<!-- Date-picker itself -->
+<script src="https://unpkg.com/eonasdan-bootstrap-datetimepicker@4.17.47/build/js/bootstrap-datetimepicker.min.js"></script>
+<link href="https://unpkg.com/eonasdan-bootstrap-datetimepicker@4.17.47/build/css/bootstrap-datetimepicker.min.css" rel="stylesheet">
+
+<!-- Vue js -->
+<script src="https://unpkg.com/vue@2.5/dist/vue.min.js"></script>
+<!-- Lastly add this package -->
+<script src="https://unpkg.com/vue-bootstrap-datetimepicker"></script>
+<script>
+  // Initialize as global component
+  Vue.component('date-picker', VueBootstrapDatetimePicker.default);
+</script>
+```
 
 ## Run examples on your localhost
 * Clone this repo
@@ -177,7 +154,6 @@ The component accepts these props:
 * Install dependencies - `yarn install`
 * Run webpack dev server - `yarn start`
 * This should open the demo page at ``http://localhost:8000`` in your default web browser
-
 
 ## Testing
 * This package is using [Jest](https://github.com/facebook/jest) and [vue-test-utils](https://github.com/vuejs/vue-test-utils) for testing.


### PR DESCRIPTION
I agree with @atleta (see https://github.com/ankurk91/vue-bootstrap-datetimepicker/issues/13#issuecomment-333124592) that the current installation manual is a bit confusing; there were two installation parts. 

So moved them together. 


preview: https://github.com/304NotModified/vue-bootstrap-datetimepicker/tree/patch-1
  